### PR TITLE
Add SendStats to AvroRecord interface

### DIFF
--- a/container/avro_record.go
+++ b/container/avro_record.go
@@ -2,9 +2,12 @@ package container
 
 import (
 	"io"
+
+	stats "github.com/securityscorecard/go-stats"
 )
 
 type AvroRecord interface {
 	Serialize(io.Writer) error
 	Schema() string
+	SendStats(stats.Statser)
 }


### PR DESCRIPTION
This should not break stuff because everything generated by our version of `gogen-avro` has a `SendStats` method.