### PR TITLE
Revert to using goformat instead of goimports

### DIFF
--- a/generator/file.go
+++ b/generator/file.go
@@ -2,12 +2,11 @@ package generator
 
 import (
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
-
-	"golang.org/x/tools/imports"
 )
 
 /*
@@ -47,7 +46,7 @@ TODO: It'd be better to group funcs attached to a struct with the struct definit
 */
 func (f *File) WriteFile(pkgName, targetFile string) error {
 	src := fmt.Sprintf("%v\npackage %v\n%v\n%v\n%v\n%v\n", f.headerString(), pkgName, f.importString(), f.constantString(), f.structString(), f.functionString())
-	fileContent, err := imports.Process("", []byte(src), nil)
+	fileContent, err := format.Source([]byte(src))
 	if err != nil {
 		return fmt.Errorf("Error formatting file %v - %v\n\nContents: %v", f.name, err, src)
 	}


### PR DESCRIPTION
Reverting this because goimports will remove any import paths that the running host doesn't have a copy of locally.