### PR TITLE
Better UUID generation

### DIFF
--- a/generator/file.go
+++ b/generator/file.go
@@ -13,21 +13,23 @@ import (
 File represents a Go source file in the output package
 */
 type File struct {
-	name      string
-	headers   []string
-	functions map[FunctionName]string
-	structs   map[string]string
-	imports   map[string]interface{}
-	constants map[string]interface{}
+	name       string
+	headers    []string
+	functions  map[FunctionName]string
+	structs    map[string]string
+	imports    map[string]interface{}
+	constants  map[string]interface{}
+	rawContent string
 }
 
 func NewFile(name string) *File {
 	return &File{
-		name:      name,
-		functions: make(map[FunctionName]string),
-		structs:   make(map[string]string),
-		imports:   make(map[string]interface{}),
-		constants: make(map[string]interface{}),
+		name:       name,
+		functions:  make(map[FunctionName]string),
+		structs:    make(map[string]string),
+		imports:    make(map[string]interface{}),
+		constants:  make(map[string]interface{}),
+		rawContent: "",
 	}
 }
 
@@ -45,7 +47,7 @@ type FunctionName struct {
 TODO: It'd be better to group funcs attached to a struct with the struct definition
 */
 func (f *File) WriteFile(pkgName, targetFile string) error {
-	src := fmt.Sprintf("%v\n\npackage %v\n%v\n%v\n%v\n%v\n", f.headerString(), pkgName, f.importString(), f.constantString(), f.structString(), f.functionString())
+	src := fmt.Sprintf("%v\n\npackage %v\n%v\n%v\n%v\n%v\n%s\n", f.headerString(), pkgName, f.importString(), f.constantString(), f.structString(), f.functionString(), f.rawContent)
 	fileContent, err := format.Source([]byte(src))
 	if err != nil {
 		return fmt.Errorf("Error formatting file %v - %v\n\nContents: %v", f.name, err, src)

--- a/generator/package.go
+++ b/generator/package.go
@@ -39,6 +39,16 @@ func (p *Package) File(name string) (*File, bool) {
 	return file, ok
 }
 
+func (p *Package) AddFile(file, fileContent string) {
+	f, ok := p.files[file]
+	if !ok {
+		f = NewFile(file)
+		p.files[file] = f
+	}
+
+	f.rawContent = fileContent
+}
+
 func (p *Package) AddHeader(file, header string) {
 	f, ok := p.files[file]
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func main() {
 		os.Exit(4)
 	}
 
+	types.AddUUIDSerializerToPackage(pkg)
+
 	// Add header comment to all generated files.
 	for _, f := range pkg.Files() {
 		pkg.AddHeader(f, codegenComment(files))

--- a/main.go
+++ b/main.go
@@ -47,8 +47,6 @@ func main() {
 		os.Exit(4)
 	}
 
-	types.AddUUIDSerializerToPackage(pkg)
-
 	// Add header comment to all generated files.
 	for _, f := range pkg.Files() {
 		pkg.AddHeader(f, codegenComment(files))

--- a/test/uuid/generate.go
+++ b/test/uuid/generate.go
@@ -1,0 +1,3 @@
+package avro
+
+//go:generate $GOPATH/bin/gogen-avro . uuid.avsc

--- a/test/uuid/schema_test.go
+++ b/test/uuid/schema_test.go
@@ -78,7 +78,7 @@ func TestStringSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hello|bye" {
+	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hello,bye" {
 		t.Fatalf("string slice serializer provided wrong result")
 	}
 
@@ -105,7 +105,7 @@ func TestInt32Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int32SliceSerializer([]int32{1, -1}); s != "1|-1" {
+	if s := int32SliceSerializer([]int32{1, -1}); s != "1,-1" {
 		t.Fatalf("int32 slice serializer provided wrong result")
 	}
 
@@ -132,7 +132,7 @@ func TestInt64Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int64SliceSerializer([]int64{1, -1}); s != "1|-1" {
+	if s := int64SliceSerializer([]int64{1, -1}); s != "1,-1" {
 		t.Fatalf("int64 slice serializer provided wrong result")
 	}
 
@@ -159,7 +159,7 @@ func TestFloat32Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000|-1.0000" {
+	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000,-1.0000" {
 		t.Fatalf("float32 slice serializer provided wrong result")
 	}
 
@@ -186,7 +186,7 @@ func TestFloat64Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000|-1.0000" {
+	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000,-1.0000" {
 		t.Fatalf("float64 slice serializer provided wrong result")
 	}
 
@@ -213,7 +213,7 @@ func TestBooleanSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := boolSliceSerializer([]bool{true, false}); s != "true|false" {
+	if s := boolSliceSerializer([]bool{true, false}); s != "true,false" {
 		t.Fatalf("bool slice serializer provided wrong result")
 	}
 
@@ -232,10 +232,10 @@ func TestBooleanSerializer(t *testing.T) {
 }
 
 func TestIPSerializer(t *testing.T) {
-	if s := ipSerializer(IPAddressZero); s != "0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0" {
+	if s := ipSerializer(IPAddressZero); s != "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" {
 		t.Fatalf("ip serialize provided wrong result")
 	}
-	if s := ipSerializer(IPAddressV4Full); s != "0|0|0|0|0|0|0|0|0|0|255|255|255|255|255|255" {
+	if s := ipSerializer(IPAddressV4Full); s != "0,0,0,0,0,0,0,0,0,0,255,255,255,255,255,255" {
 		t.Fatalf("ip serialize provided wrong result")
 	}
 }

--- a/test/uuid/schema_test.go
+++ b/test/uuid/schema_test.go
@@ -1,6 +1,9 @@
 package avro
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 var (
 	IPAddressZero   = IPAddress{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
@@ -13,8 +16,6 @@ func TestUUIDGenerationDeterministic(t *testing.T) {
 		Boolean:   true,
 		Int:       1,
 		Long:      2,
-		Float:     4.0,
-		Double:    3.0,
 		IPAddress: IPAddressZero,
 		Object: &Object{
 			Name: "Boop",
@@ -25,8 +26,6 @@ func TestUUIDGenerationDeterministic(t *testing.T) {
 		BooleanArray: []bool{true},
 		IntArray:     []int32{1, 2},
 		LongArray:    []int64{3, 4},
-		FloatArray:   []float32{4.5, 5.5},
-		DoubleArray:  []float64{1.0, -1.0},
 
 		// unions
 		NullableString: UnionNullString{
@@ -44,14 +43,6 @@ func TestUUIDGenerationDeterministic(t *testing.T) {
 		NullableLong: UnionNullLong{
 			Long:      2,
 			UnionType: UnionNullLongTypeEnumLong,
-		},
-		NullableFloat: UnionNullFloat{
-			Float:     3.0,
-			UnionType: UnionNullFloatTypeEnumFloat,
-		},
-		NullableDouble: UnionNullDouble{
-			Double:    4.0,
-			UnionType: UnionNullDoubleTypeEnumDouble,
 		},
 	}
 
@@ -78,7 +69,8 @@ func TestStringSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hello,bye" {
+	expectedResult := "hello" + ArraySeparator + "bye"
+	if s := stringSliceSerializer([]string{"hello", "bye"}); s != expectedResult {
 		t.Fatalf("string slice serializer provided wrong result")
 	}
 
@@ -105,7 +97,8 @@ func TestInt32Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int32SliceSerializer([]int32{1, -1}); s != "1,-1" {
+	expectedResult := "1" + ArraySeparator + "-1"
+	if s := int32SliceSerializer([]int32{1, -1}); s != expectedResult {
 		t.Fatalf("int32 slice serializer provided wrong result")
 	}
 
@@ -132,7 +125,8 @@ func TestInt64Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int64SliceSerializer([]int64{1, -1}); s != "1,-1" {
+	expectedResult := "1" + ArraySeparator + "-1"
+	if s := int64SliceSerializer([]int64{1, -1}); s != expectedResult {
 		t.Fatalf("int64 slice serializer provided wrong result")
 	}
 
@@ -150,60 +144,6 @@ func TestInt64Serializer(t *testing.T) {
 	}
 }
 
-func TestFloat32Serializer(t *testing.T) {
-	if s := float32Serializer(1); s != "1.0000" {
-		t.Fatalf("float32 serializer provided wrong result")
-	}
-	if s := float32Serializer(-1); s != "-1.0000" {
-		t.Fatalf("float32 serializer provided wrong result")
-	}
-
-	// list
-	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000,-1.0000" {
-		t.Fatalf("float32 slice serializer provided wrong result")
-	}
-
-	// union
-	if s := unionNullFloatSerializer(UnionNullFloat{
-		Float:     1.0,
-		UnionType: UnionNullFloatTypeEnumFloat,
-	}); s != "1.0000" {
-		t.Fatalf("nullable float32 serializer provided wrong result")
-	}
-	if s := unionNullFloatSerializer(UnionNullFloat{
-		UnionType: UnionNullFloatTypeEnumNull,
-	}); s != "" {
-		t.Fatalf("nullable float32 serializer provided wrong result")
-	}
-}
-
-func TestFloat64Serializer(t *testing.T) {
-	if s := float64Serializer(1); s != "1.0000" {
-		t.Fatalf("float64 serializer provided wrong result")
-	}
-	if s := float64Serializer(-1); s != "-1.0000" {
-		t.Fatalf("float64 serializer provided wrong result")
-	}
-
-	// list
-	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000,-1.0000" {
-		t.Fatalf("float64 slice serializer provided wrong result")
-	}
-
-	// union
-	if s := unionNullDoubleSerializer(UnionNullDouble{
-		Double:    1.0,
-		UnionType: UnionNullDoubleTypeEnumDouble,
-	}); s != "1.0000" {
-		t.Fatalf("nullable float64 serializer provided wrong result")
-	}
-	if s := unionNullDoubleSerializer(UnionNullDouble{
-		UnionType: UnionNullDoubleTypeEnumNull,
-	}); s != "" {
-		t.Fatalf("nullable float64 serializer provided wrong result")
-	}
-}
-
 func TestBooleanSerializer(t *testing.T) {
 	if s := boolSerializer(false); s != "false" {
 		t.Fatalf("bool serializer provided wrong result")
@@ -213,7 +153,8 @@ func TestBooleanSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := boolSliceSerializer([]bool{true, false}); s != "true,false" {
+	expectedResult := "true" + ArraySeparator + "false"
+	if s := boolSliceSerializer([]bool{true, false}); s != expectedResult {
 		t.Fatalf("bool slice serializer provided wrong result")
 	}
 
@@ -232,10 +173,21 @@ func TestBooleanSerializer(t *testing.T) {
 }
 
 func TestIPSerializer(t *testing.T) {
-	if s := ipSerializer(IPAddressZero); s != "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" {
+	// case IPAddressZero
+	expectedResult := strings.Join(
+		[]string{"0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "0"},
+		ArraySeparator,
+	)
+	if s := ipSerializer(IPAddressZero); s != expectedResult {
 		t.Fatalf("ip serialize provided wrong result")
 	}
-	if s := ipSerializer(IPAddressV4Full); s != "0,0,0,0,0,0,0,0,0,0,255,255,255,255,255,255" {
+
+	// case IPAddressV4Full
+	expectedResult = strings.Join(
+		[]string{"0", "0", "0", "0", "0", "0", "0", "0", "0", "0", "255", "255", "255", "255", "255", "255"},
+		ArraySeparator,
+	)
+	if s := ipSerializer(IPAddressV4Full); s != expectedResult {
 		t.Fatalf("ip serialize provided wrong result")
 	}
 }

--- a/test/uuid/schema_test.go
+++ b/test/uuid/schema_test.go
@@ -78,7 +78,7 @@ func TestStringSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hellobye" {
+	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hello|bye" {
 		t.Fatalf("string slice serializer provided wrong result")
 	}
 
@@ -105,7 +105,7 @@ func TestInt32Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int32SliceSerializer([]int32{1, -1}); s != "1-1" {
+	if s := int32SliceSerializer([]int32{1, -1}); s != "1|-1" {
 		t.Fatalf("int32 slice serializer provided wrong result")
 	}
 
@@ -132,7 +132,7 @@ func TestInt64Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := int64SliceSerializer([]int64{1, -1}); s != "1-1" {
+	if s := int64SliceSerializer([]int64{1, -1}); s != "1|-1" {
 		t.Fatalf("int64 slice serializer provided wrong result")
 	}
 
@@ -159,7 +159,7 @@ func TestFloat32Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000-1.0000" {
+	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000|-1.0000" {
 		t.Fatalf("float32 slice serializer provided wrong result")
 	}
 
@@ -186,7 +186,7 @@ func TestFloat64Serializer(t *testing.T) {
 	}
 
 	// list
-	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000-1.0000" {
+	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000|-1.0000" {
 		t.Fatalf("float64 slice serializer provided wrong result")
 	}
 
@@ -213,7 +213,7 @@ func TestBooleanSerializer(t *testing.T) {
 	}
 
 	// list
-	if s := boolSliceSerializer([]bool{true, false}); s != "truefalse" {
+	if s := boolSliceSerializer([]bool{true, false}); s != "true|false" {
 		t.Fatalf("bool slice serializer provided wrong result")
 	}
 
@@ -232,10 +232,10 @@ func TestBooleanSerializer(t *testing.T) {
 }
 
 func TestIPSerializer(t *testing.T) {
-	if s := ipSerializer(IPAddressZero); s != "0000000000000000" {
+	if s := ipSerializer(IPAddressZero); s != "0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0" {
 		t.Fatalf("ip serialize provided wrong result")
 	}
-	if s := ipSerializer(IPAddressV4Full); s != "0000000000255255255255255255" {
+	if s := ipSerializer(IPAddressV4Full); s != "0|0|0|0|0|0|0|0|0|0|255|255|255|255|255|255" {
 		t.Fatalf("ip serialize provided wrong result")
 	}
 }

--- a/test/uuid/schema_test.go
+++ b/test/uuid/schema_test.go
@@ -13,10 +13,45 @@ func TestUUIDGenerationDeterministic(t *testing.T) {
 		Boolean:   true,
 		Int:       1,
 		Long:      2,
+		Float:     4.0,
 		Double:    3.0,
 		IPAddress: IPAddressZero,
 		Object: &Object{
 			Name: "Boop",
+		},
+
+		// lists
+		StringArray:  []string{""},
+		BooleanArray: []bool{true},
+		IntArray:     []int32{1, 2},
+		LongArray:    []int64{3, 4},
+		FloatArray:   []float32{4.5, 5.5},
+		DoubleArray:  []float64{1.0, -1.0},
+
+		// unions
+		NullableString: UnionNullString{
+			String:    "",
+			UnionType: UnionNullStringTypeEnumString,
+		},
+		NullableBoolean: UnionNullBool{
+			Bool:      true,
+			UnionType: UnionNullBoolTypeEnumBool,
+		},
+		NullableInt: UnionNullInt{
+			Int:       1,
+			UnionType: UnionNullIntTypeEnumInt,
+		},
+		NullableLong: UnionNullLong{
+			Long:      2,
+			UnionType: UnionNullLongTypeEnumLong,
+		},
+		NullableFloat: UnionNullFloat{
+			Float:     3.0,
+			UnionType: UnionNullFloatTypeEnumFloat,
+		},
+		NullableDouble: UnionNullDouble{
+			Double:    4.0,
+			UnionType: UnionNullDoubleTypeEnumDouble,
 		},
 	}
 
@@ -41,20 +76,23 @@ func TestStringSerializer(t *testing.T) {
 	if s := stringSerializer("hello"); s != "hello" {
 		t.Fatalf("string serializer provided wrong result")
 	}
+
+	// list
 	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hellobye" {
 		t.Fatalf("string slice serializer provided wrong result")
 	}
-}
 
-func TestIntSerializer(t *testing.T) {
-	if s := intSerializer(1); s != "1" {
-		t.Fatalf("int serializer provided wrong result")
+	// union
+	if s := unionNullStringSerializer(UnionNullString{
+		String:    "hello",
+		UnionType: UnionNullStringTypeEnumString,
+	}); s != "hello" {
+		t.Fatalf("nullable string serializer provided wrong result")
 	}
-	if s := intSerializer(-1); s != "-1" {
-		t.Fatalf("int serializer provided wrong result")
-	}
-	if s := intSliceSerializer([]int{1, -1}); s != "1-1" {
-		t.Fatalf("int slice serializer provided wrong result")
+	if s := unionNullStringSerializer(UnionNullString{
+		UnionType: UnionNullStringTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable string serializer provided wrong result")
 	}
 }
 
@@ -65,8 +103,23 @@ func TestInt32Serializer(t *testing.T) {
 	if s := int32Serializer(-1); s != "-1" {
 		t.Fatalf("int32 serializer provided wrong result")
 	}
+
+	// list
 	if s := int32SliceSerializer([]int32{1, -1}); s != "1-1" {
 		t.Fatalf("int32 slice serializer provided wrong result")
+	}
+
+	// union
+	if s := unionNullIntSerializer(UnionNullInt{
+		Int:       -1,
+		UnionType: UnionNullIntTypeEnumInt,
+	}); s != "-1" {
+		t.Fatalf("nullable int32 serializer provided wrong result")
+	}
+	if s := unionNullIntSerializer(UnionNullInt{
+		UnionType: UnionNullIntTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable int32 serializer provided wrong result")
 	}
 }
 
@@ -77,8 +130,23 @@ func TestInt64Serializer(t *testing.T) {
 	if s := int64Serializer(-1); s != "-1" {
 		t.Fatalf("int64 serializer provided wrong result")
 	}
+
+	// list
 	if s := int64SliceSerializer([]int64{1, -1}); s != "1-1" {
 		t.Fatalf("int64 slice serializer provided wrong result")
+	}
+
+	// union
+	if s := unionNullLongSerializer(UnionNullLong{
+		Long:      -1,
+		UnionType: UnionNullLongTypeEnumLong,
+	}); s != "-1" {
+		t.Fatalf("nullable int64 serializer provided wrong result")
+	}
+	if s := unionNullLongSerializer(UnionNullLong{
+		UnionType: UnionNullLongTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable int64 serializer provided wrong result")
 	}
 }
 
@@ -89,8 +157,23 @@ func TestFloat32Serializer(t *testing.T) {
 	if s := float32Serializer(-1); s != "-1.0000" {
 		t.Fatalf("float32 serializer provided wrong result")
 	}
+
+	// list
 	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000-1.0000" {
 		t.Fatalf("float32 slice serializer provided wrong result")
+	}
+
+	// union
+	if s := unionNullFloatSerializer(UnionNullFloat{
+		Float:     1.0,
+		UnionType: UnionNullFloatTypeEnumFloat,
+	}); s != "1.0000" {
+		t.Fatalf("nullable float32 serializer provided wrong result")
+	}
+	if s := unionNullFloatSerializer(UnionNullFloat{
+		UnionType: UnionNullFloatTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable float32 serializer provided wrong result")
 	}
 }
 
@@ -101,8 +184,23 @@ func TestFloat64Serializer(t *testing.T) {
 	if s := float64Serializer(-1); s != "-1.0000" {
 		t.Fatalf("float64 serializer provided wrong result")
 	}
+
+	// list
 	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000-1.0000" {
 		t.Fatalf("float64 slice serializer provided wrong result")
+	}
+
+	// union
+	if s := unionNullDoubleSerializer(UnionNullDouble{
+		Double:    1.0,
+		UnionType: UnionNullDoubleTypeEnumDouble,
+	}); s != "1.0000" {
+		t.Fatalf("nullable float64 serializer provided wrong result")
+	}
+	if s := unionNullDoubleSerializer(UnionNullDouble{
+		UnionType: UnionNullDoubleTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable float64 serializer provided wrong result")
 	}
 }
 
@@ -113,8 +211,23 @@ func TestBooleanSerializer(t *testing.T) {
 	if s := boolSerializer(true); s != "true" {
 		t.Fatalf("bool serializer provided wrong result")
 	}
+
+	// list
 	if s := boolSliceSerializer([]bool{true, false}); s != "truefalse" {
 		t.Fatalf("bool slice serializer provided wrong result")
+	}
+
+	// union
+	if s := unionNullBoolSerializer(UnionNullBool{
+		Bool:      true,
+		UnionType: UnionNullBoolTypeEnumBool,
+	}); s != "true" {
+		t.Fatalf("nullable boolean serializer provided wrong result")
+	}
+	if s := unionNullBoolSerializer(UnionNullBool{
+		UnionType: UnionNullBoolTypeEnumNull,
+	}); s != "" {
+		t.Fatalf("nullable boolean serializer provided wrong result")
 	}
 }
 

--- a/test/uuid/schema_test.go
+++ b/test/uuid/schema_test.go
@@ -1,0 +1,128 @@
+package avro
+
+import "testing"
+
+var (
+	IPAddressZero   = IPAddress{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	IPAddressV4Full = IPAddress{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255}
+)
+
+func TestUUIDGenerationDeterministic(t *testing.T) {
+	u := UUID{
+		String:    "",
+		Boolean:   true,
+		Int:       1,
+		Long:      2,
+		Double:    3.0,
+		IPAddress: IPAddressZero,
+		Object: &Object{
+			Name: "Boop",
+		},
+	}
+
+	// Test that ID generation is deterministic and depends on field values
+	idA := u.GenerateID()
+	idB := u.GenerateID()
+
+	if idA != idB {
+		t.Fatalf("expected ids to be identical")
+	}
+
+	// Changing a field value should change the ID
+	u.String = "string"
+	idC := u.GenerateID()
+
+	if idA == idC {
+		t.Fatalf("expected ids to be different")
+	}
+}
+
+func TestStringSerializer(t *testing.T) {
+	if s := stringSerializer("hello"); s != "hello" {
+		t.Fatalf("string serializer provided wrong result")
+	}
+	if s := stringSliceSerializer([]string{"hello", "bye"}); s != "hellobye" {
+		t.Fatalf("string slice serializer provided wrong result")
+	}
+}
+
+func TestIntSerializer(t *testing.T) {
+	if s := intSerializer(1); s != "1" {
+		t.Fatalf("int serializer provided wrong result")
+	}
+	if s := intSerializer(-1); s != "-1" {
+		t.Fatalf("int serializer provided wrong result")
+	}
+	if s := intSliceSerializer([]int{1, -1}); s != "1-1" {
+		t.Fatalf("int slice serializer provided wrong result")
+	}
+}
+
+func TestInt32Serializer(t *testing.T) {
+	if s := int32Serializer(1); s != "1" {
+		t.Fatalf("int32 serializer provided wrong result")
+	}
+	if s := int32Serializer(-1); s != "-1" {
+		t.Fatalf("int32 serializer provided wrong result")
+	}
+	if s := int32SliceSerializer([]int32{1, -1}); s != "1-1" {
+		t.Fatalf("int32 slice serializer provided wrong result")
+	}
+}
+
+func TestInt64Serializer(t *testing.T) {
+	if s := int64Serializer(1); s != "1" {
+		t.Fatalf("int64 serializer provided wrong result")
+	}
+	if s := int64Serializer(-1); s != "-1" {
+		t.Fatalf("int64 serializer provided wrong result")
+	}
+	if s := int64SliceSerializer([]int64{1, -1}); s != "1-1" {
+		t.Fatalf("int64 slice serializer provided wrong result")
+	}
+}
+
+func TestFloat32Serializer(t *testing.T) {
+	if s := float32Serializer(1); s != "1.0000" {
+		t.Fatalf("float32 serializer provided wrong result")
+	}
+	if s := float32Serializer(-1); s != "-1.0000" {
+		t.Fatalf("float32 serializer provided wrong result")
+	}
+	if s := float32SliceSerializer([]float32{1, -1}); s != "1.0000-1.0000" {
+		t.Fatalf("float32 slice serializer provided wrong result")
+	}
+}
+
+func TestFloat64Serializer(t *testing.T) {
+	if s := float64Serializer(1); s != "1.0000" {
+		t.Fatalf("float64 serializer provided wrong result")
+	}
+	if s := float64Serializer(-1); s != "-1.0000" {
+		t.Fatalf("float64 serializer provided wrong result")
+	}
+	if s := float64SliceSerializer([]float64{1, -1}); s != "1.0000-1.0000" {
+		t.Fatalf("float64 slice serializer provided wrong result")
+	}
+}
+
+func TestBooleanSerializer(t *testing.T) {
+	if s := boolSerializer(false); s != "false" {
+		t.Fatalf("bool serializer provided wrong result")
+	}
+	if s := boolSerializer(true); s != "true" {
+		t.Fatalf("bool serializer provided wrong result")
+	}
+	if s := boolSliceSerializer([]bool{true, false}); s != "truefalse" {
+		t.Fatalf("bool slice serializer provided wrong result")
+	}
+}
+
+func TestIPSerializer(t *testing.T) {
+	if s := ipSerializer(IPAddressZero); s != "0000000000000000" {
+		t.Fatalf("ip serialize provided wrong result")
+	}
+	if s := ipSerializer(IPAddressV4Full); s != "0000000000255255255255255255" {
+		t.Fatalf("ip serialize provided wrong result")
+	}
+}

--- a/test/uuid/uuid.avsc
+++ b/test/uuid/uuid.avsc
@@ -9,20 +9,90 @@
             "type": "string"
         },
         {
+            "name": "string_array",
+            "type": {
+              "type": "array",
+              "items": "string"
+            }
+        },
+        {
+            "name": "nullable_string",
+            "type": ["null", "string"]
+        },
+        {
             "name": "boolean",
             "type": "boolean"
+        },
+        {
+            "name": "boolean_array",
+            "type": {
+              "type": "array",
+              "items": "boolean"
+            }
+        },
+        {
+            "name": "nullable_boolean",
+            "type": ["null", "boolean"]
         },
         {
             "name": "int",
             "type": "int"
         },
         {
+            "name": "int_array",
+            "type": {
+              "type": "array",
+              "items": "int"
+            }
+        },
+        {
+            "name": "nullable_int",
+            "type": ["null", "int"]
+        },
+        {
             "name": "long",
             "type": "long"
         },
         {
+            "name": "long_array",
+            "type": {
+              "type": "array",
+              "items": "long"
+            }
+        },
+        {
+            "name": "nullable_long",
+            "type": ["null", "long"]
+        },
+        {
+            "name": "float",
+            "type": "float"
+        },
+        {
+            "name": "float_array",
+            "type": {
+              "type": "array",
+              "items": "float"
+            }
+        },
+        {
+            "name": "nullable_float",
+            "type": ["null", "float"]
+        },
+        {
             "name": "double",
             "type": "double"
+        },
+        {
+            "name": "double_array",
+            "type": {
+              "type": "array",
+              "items": "double"
+            }
+        },
+        {
+            "name": "nullable_double",
+            "type": ["null", "double"]
         },
         {
             "name": "ip_address",
@@ -51,8 +121,21 @@
         "boolean",
         "int",
         "long",
+        "float",
         "double",
         "ip_address",
-        "object.name"
+        "object.name",
+        "string_array",
+        "boolean_array",
+        "int_array",
+        "long_array",
+        "float_array",
+        "double_array",
+        "nullable_string",
+        "nullable_boolean",
+        "nullable_int",
+        "nullable_long",
+        "nullable_float",
+        "nullable_double"
     ]
 }

--- a/test/uuid/uuid.avsc
+++ b/test/uuid/uuid.avsc
@@ -65,36 +65,6 @@
             "type": ["null", "long"]
         },
         {
-            "name": "float",
-            "type": "float"
-        },
-        {
-            "name": "float_array",
-            "type": {
-              "type": "array",
-              "items": "float"
-            }
-        },
-        {
-            "name": "nullable_float",
-            "type": ["null", "float"]
-        },
-        {
-            "name": "double",
-            "type": "double"
-        },
-        {
-            "name": "double_array",
-            "type": {
-              "type": "array",
-              "items": "double"
-            }
-        },
-        {
-            "name": "nullable_double",
-            "type": ["null", "double"]
-        },
-        {
             "name": "ip_address",
             "type": {
                 "type": "fixed",
@@ -121,21 +91,15 @@
         "boolean",
         "int",
         "long",
-        "float",
-        "double",
         "ip_address",
         "object.name",
         "string_array",
         "boolean_array",
         "int_array",
         "long_array",
-        "float_array",
-        "double_array",
         "nullable_string",
         "nullable_boolean",
         "nullable_int",
-        "nullable_long",
-        "nullable_float",
-        "nullable_double"
+        "nullable_long"
     ]
 }

--- a/test/uuid/uuid.avsc
+++ b/test/uuid/uuid.avsc
@@ -1,0 +1,58 @@
+{
+    "type": "record",
+    "namespace": "com.securityscorecard.collections",
+    "name": "uuid",
+    "subject": "com.securityscorecard.collections.uuid",
+    "fields": [
+        {
+            "name": "string",
+            "type": "string"
+        },
+        {
+            "name": "boolean",
+            "type": "boolean"
+        },
+        {
+            "name": "int",
+            "type": "int"
+        },
+        {
+            "name": "long",
+            "type": "long"
+        },
+        {
+            "name": "double",
+            "type": "double"
+        },
+        {
+            "name": "ip_address",
+            "type": {
+                "type": "fixed",
+                "size": 16,
+                "name": "ip_address"
+            }
+        },
+        {
+            "name": "object",
+            "type": {
+                "name": "object",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string"
+                    }
+                ]
+            }
+        }
+    ],
+    "uuid_keys": [
+        "string",
+        "boolean",
+        "int",
+        "long",
+        "double",
+        "ip_address",
+        "object.name"
+    ]
+}

--- a/types/record.go
+++ b/types/record.go
@@ -209,6 +209,7 @@ func (r *RecordDefinition) Schema(names map[QualifiedName]interface{}) interface
 func (r *RecordDefinition) AddGenerateID(p *generator.Package) {
 	// Import guard, to avoid circular dependencies
 	if !p.HasFunction(r.filename(), "", "GenerateID") {
+		p.AddImport(r.filename(), "fmt")
 		p.AddImport(r.filename(), "github.com/satori/go.uuid")
 
 		uuidStrDef, requiredSerializers := r.uuidStrDef()
@@ -216,7 +217,7 @@ func (r *RecordDefinition) AddGenerateID(p *generator.Package) {
 		// Create function definition
 		fnDef := fmt.Sprintf(`
 			func (r %v) GenerateID() string {
-				s := %s
+				s := fmt.Println(%s)
 				return uuid.NewV5(uuid.NamespaceOID, s).String()
 			}
 		`, r.GoType(), uuidStrDef)

--- a/types/record.go
+++ b/types/record.go
@@ -336,7 +336,7 @@ func (r *RecordDefinition) uuidStrDef() (string, []string) {
 	strDef := `"`
 	for i := 0; i < len(fieldsToInclude); i++ {
 		if i != 0 {
-			strDef += ","
+			strDef += "|"
 		}
 		strDef += "%s"
 	}

--- a/types/record.go
+++ b/types/record.go
@@ -255,6 +255,9 @@ func (r *RecordDefinition) uuidStrDef() string {
 		// float
 		"float32": true, "[]float32": true,
 		"float64": true, "[]float64": true,
+
+		// ip
+		"IPAddress": true,
 	}
 
 	availFields := map[string]string{}

--- a/types/record.go
+++ b/types/record.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -291,6 +292,11 @@ func (r *RecordDefinition) uuidStrDef() string {
 	fieldsToInclude := []uuidField{}
 	for _, uuidKey := range schema.UUIDKeys {
 		fName := uuidToFieldName(uuidKey)
+		if _, ok := availFields[fName]; !ok {
+			fmt.Printf("Error: can't use %s as a uuid key\n", uuidKey)
+			os.Exit(1)
+		}
+
 		fieldsToInclude = append(fieldsToInclude, uuidField{Name: fName, Type: availFields[fName]})
 	}
 

--- a/types/record.go
+++ b/types/record.go
@@ -241,14 +241,6 @@ func extractAvailableFields(f Field) map[string]string {
 	// union case
 	un, ok := f.(*unionField)
 	if ok {
-		// Only allow a union of two types where the first type is nil
-		if len(un.itemType) != 2 {
-			panic("unions are only allowed to contain two types")
-		}
-		if _, ok := un.itemType[0].(*nullField); !ok {
-			panic("unions must have null as their first type")
-		}
-
 		// The second type must be an allowed type
 		typ := un.itemType[1].GoType()
 		if _, ok := allowedFieldTypes[typ]; ok {

--- a/types/record.go
+++ b/types/record.go
@@ -217,7 +217,7 @@ func (r *RecordDefinition) AddGenerateID(p *generator.Package) {
 		// Create function definition
 		fnDef := fmt.Sprintf(`
 			func (r %v) GenerateID() string {
-				s := fmt.Println(%s)
+				s := fmt.Sprint(%s)
 				return uuid.NewV5(uuid.NamespaceOID, s).String()
 			}
 		`, r.GoType(), uuidStrDef)

--- a/types/record.go
+++ b/types/record.go
@@ -343,6 +343,9 @@ func (r *RecordDefinition) uuidStrDef() (string, []string) {
 
 	strDef := `"`
 	for i := 0; i < len(fieldsToInclude); i++ {
+		if i != 0 {
+			strDef += ","
+		}
 		strDef += "%s"
 	}
 	strDef += `"`

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -1,0 +1,125 @@
+package types
+
+import "github.com/alanctgardner/gogen-avro/generator"
+
+func AddUUIDSerializerToPackage(pkg *generator.Package) {
+	pkg.AddFile("uuid_serializers.go", uuidSerializersFileContent)
+}
+
+var typeSerializerFuncs = map[string]string{
+	"byte": "byteSerializer", "[]byte": "byteSliceSerializer",
+	"bool": "boolSerializer", "[]bool": "boolSliceSerializer",
+	"string": "stringSerializer", "[]string": "stringSliceSerializer",
+
+	// int
+	"int": "intSerializer", "[]int": "intSliceSerializer",
+	"int32": "intSerializer", "[]int32": "intSliceSerializer",
+	"int64": "intSerializer", "[]int64": "intSliceSerializer",
+
+	// float
+	"float32": "floatSerializer", "[]float32": "floatSliceSerializer",
+	"float64": "floatSerializer", "[]float64": "floatSliceSerializer",
+}
+
+var uuidSerializersFileContent = `
+import "fmt"
+
+type fieldTypeSerializer func(interface{}) string
+
+var byteSerializer = fieldTypeSerializer(func(i interface{}) string {
+	v := i.(byte)
+	return fmt.Sprintf("%d", v)
+})
+
+var byteSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vs := i.([]byte)
+	out := ""
+	for _, v := range vs {
+		out += fmt.Sprintf("%d", v)
+	}
+	return out
+})
+
+var stringSerializer = fieldTypeSerializer(func(i interface{}) string {
+	v := i.(string)
+	return v
+})
+
+var stringSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vs := i.([]string)
+	out := ""
+	for _, v := range vs {
+		out += v
+	}
+	return out
+})
+
+var boolSerializer = fieldTypeSerializer(func(i interface{}) string {
+	return fmt.Sprintf("%v", i)
+})
+
+var boolSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vs := i.([]bool)
+	out := ""
+	for _, v := range vs {
+		out += fmt.Sprintf("%v", v)
+	}
+	return out
+})
+
+var intSerializer = fieldTypeSerializer(func(i interface{}) string {
+	return fmt.Sprintf("%d", i)
+})
+
+var intSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vsint, ok := i.([]int)
+	if ok {
+		out := ""
+		for _, v := range vsint {
+			out += fmt.Sprintf("%d", v)
+		}
+		return out
+	}
+	vsint32, ok := i.([]int32)
+	if ok {
+		out := ""
+		for _, v := range vsint32 {
+			out += fmt.Sprintf("%d", v)
+		}
+		return out
+	}
+	vsint64, ok := i.([]int64)
+	if ok {
+		out := ""
+		for _, v := range vsint64 {
+			out += fmt.Sprintf("%d", v)
+		}
+		return out
+	}
+	panic("invalid type: expected int, int32 or int64")
+})
+
+var floatSerializer = fieldTypeSerializer(func(i interface{}) string {
+	return fmt.Sprintf("%.4f", i)
+})
+
+var floatSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vsf32, ok := i.([]float32)
+	if ok {
+		out := ""
+		for _, v := range vsf32 {
+			out += fmt.Sprintf("%.4f", v)
+		}
+		return out
+	}
+	vsf64, ok := i.([]float64)
+	if ok {
+		out := ""
+		for _, v := range vsf64 {
+			out += fmt.Sprintf("%.4f", v)
+		}
+		return out
+	}
+	panic("invalid type: expected float32 or float64")
+})
+`

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -182,7 +182,7 @@ var intSliceSerializer = `
 	func intSliceSerializer(vs []int) string {
 		out := ""
 		for _, v := range vs {
-			out += intSerializer(v)
+			out += fmt.Sprintf("%d", v)
 		}
 		return out
 	}
@@ -192,7 +192,7 @@ var int32SliceSerializer = `
 	func int32SliceSerializer(vs []int32) string {
 		out := ""
 		for _, v := range vs {
-			out += int32Serializer(v)
+			out += fmt.Sprintf("%d", v)
 		}
 		return out
 	}
@@ -202,7 +202,7 @@ var int64SliceSerializer = `
 	func int64SliceSerializer(vs []int64) string {
 		out := ""
 		for _, v := range vs {
-			out += int64Serializer(v)
+			out += fmt.Sprintf("%d", v)
 		}
 		return out
 	}
@@ -226,7 +226,7 @@ var float32SliceSerializer = `
 	func float32SliceSerializer(vs []float32) string {
 		out := ""
 		for _, v := range vs {
-			out += float32Serializer(v)
+			out += fmt.Sprintf("%.4f", v)
 		}
 		return out
 	}
@@ -236,7 +236,7 @@ var float64SliceSerializer = `
 	func float64SliceSerializer(vs []float64) string {
 		out := ""
 		for _, v := range vs {
-			out += float64Serializer(v)
+			out += fmt.Sprintf("%.4f", v)
 		}
 		return out
 	}

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -122,7 +122,7 @@ var byteSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -143,7 +143,7 @@ var stringSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += v
 		}
@@ -164,7 +164,7 @@ var boolSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%v", v)
 		}
@@ -197,7 +197,7 @@ var intSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -210,7 +210,7 @@ var int32SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -223,7 +223,7 @@ var int64SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -250,7 +250,7 @@ var float32SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%.4f", v)
 		}
@@ -263,7 +263,7 @@ var float64SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%.4f", v)
 		}
@@ -278,7 +278,7 @@ var ipSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += ","
+				out += ArraySeparator
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -348,7 +348,7 @@ var unionNullIPAddressSerializer = `
 			out := ""
 			for i, v := range un.IPAddress {
 				if i != 0 {
-					out += ","
+					out += ArraySeparator
 				}
 				out += fmt.Sprintf("%d", v)
 			}
@@ -361,5 +361,10 @@ var unionNullIPAddressSerializer = `
 var uuidSerializersFileContent = `
 import (
 	"fmt"
+)
+
+const (
+	FieldSeparator = string(0x1E)
+	ArraySeparator = string(0x1F)
 )
 `

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -9,6 +9,11 @@ import (
 // AddUUIDSerializerToPackage will add a file with Serializer functions
 // to the generated package code
 func AddUUIDSerializerToPackage(pkg *generator.Package, requiredSerializers []string) {
+	// Don't create the file if no uuid serializers are required
+	if len(requiredSerializers) == 0 {
+		return
+	}
+
 	fileContent := uuidSerializersFileContent
 
 	for _, reqSer := range requiredSerializers {

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -24,6 +24,15 @@ var allowedFieldTypes = map[string]bool{
 
 	// ip
 	"IPAddress": true,
+
+	// unions
+	"UnionNullString":    true,
+	"UnionNullInt":       true,
+	"UnionNullLong":      true,
+	"UnionNullFloat":     true,
+	"UnionNullDouble":    true,
+	"UnionNullBool":      true,
+	"UnionNullIPAddress": true,
 }
 
 var typeSerializerFuncs = map[string]string{
@@ -42,6 +51,15 @@ var typeSerializerFuncs = map[string]string{
 
 	// IP related
 	"IPAddress": "ipSerializer",
+
+	// unions
+	"UnionNullString":    "unionNullStringSerializer",
+	"UnionNullInt":       "unionNullIntSerializer",
+	"UnionNullLong":      "unionNullLongSerializer",
+	"UnionNullFloat":     "unionNullFloatSerializer",
+	"UnionNullDouble":    "unionNullDoubleSerializer",
+	"UnionNullBool":      "unionNullBoolSerializer",
+	"UnionNullIPAddress": "unionNullIPAddressSerializer",
 }
 
 var uuidSerializersFileContent = `
@@ -163,5 +181,60 @@ func float64SliceSerializer(vs []float64) string {
 		out += float64Serializer(v)
 	}
 	return out
+}
+
+// unions
+
+func unionNullStringSerializer(un UnionNullString) string {
+	if un.UnionType == UnionNullStringTypeEnumString {
+		return un.String
+	}
+	return ""
+}
+
+func unionNullIntSerializer(un UnionNullInt) string {
+	if un.UnionType == UnionNullIntTypeEnumInt {
+		return fmt.Sprintf("%d", un.Int)
+	}
+	return ""
+}
+
+func unionNullLongSerializer(un UnionNullLong) string {
+	if un.UnionType == UnionNullLongTypeEnumLong {
+		return fmt.Sprintf("%d", un.Long)
+	}
+	return ""
+}
+
+func unionNullFloatSerializer(un UnionNullFloat) string {
+	if un.UnionType == UnionNullFloatTypeEnumFloat {
+		return fmt.Sprintf("%.4f", un.Float)
+	}
+	return ""
+}
+
+func unionNullDoubleSerializer(un UnionNullDouble) string {
+	if un.UnionType == UnionNullDoubleTypeEnumDouble {
+		return fmt.Sprintf("%.4f", un.Double)
+	}
+	return ""
+}
+
+func unionNullBoolSerializer(un UnionNullBool) string {
+	if un.UnionType == UnionNullBoolTypeEnumBool {
+		return fmt.Sprintf("%v", un.Bool)
+	}
+	return ""
+}
+
+func unionNullIPAddressSerializer(un UnionNullIPAddress) string {
+	if un.UnionType == UnionNullIPAddressTypeEnumIPAddress {
+		out := ""
+		for _, v := range un.IPAddress {
+			out += fmt.Sprintf("%d", v)
+		}
+		return out
+	}
+	return ""
 }
 `

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -115,7 +115,10 @@ var byteSerializer = `
 var byteSliceSerializer = `
 	func byteSliceSerializer(vs []byte) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%d", v)
 		}
 		return out
@@ -133,7 +136,10 @@ var stringSerializer = `
 var stringSliceSerializer = `
 	func stringSliceSerializer(vs []string) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += v
 		}
 		return out
@@ -151,7 +157,10 @@ var boolSerializer = `
 var boolSliceSerializer = `
 	func boolSliceSerializer(vs []bool) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%v", v)
 		}
 		return out
@@ -181,7 +190,10 @@ var int64Serializer = `
 var intSliceSerializer = `
 	func intSliceSerializer(vs []int) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%d", v)
 		}
 		return out
@@ -191,7 +203,10 @@ var intSliceSerializer = `
 var int32SliceSerializer = `
 	func int32SliceSerializer(vs []int32) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%d", v)
 		}
 		return out
@@ -201,7 +216,10 @@ var int32SliceSerializer = `
 var int64SliceSerializer = `
 	func int64SliceSerializer(vs []int64) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%d", v)
 		}
 		return out
@@ -225,7 +243,10 @@ var float64Serializer = `
 var float32SliceSerializer = `
 	func float32SliceSerializer(vs []float32) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%.4f", v)
 		}
 		return out
@@ -235,7 +256,10 @@ var float32SliceSerializer = `
 var float64SliceSerializer = `
 	func float64SliceSerializer(vs []float64) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%.4f", v)
 		}
 		return out
@@ -247,7 +271,10 @@ var float64SliceSerializer = `
 var ipSerializer = `
 	func ipSerializer(vs IPAddress) string {
 		out := ""
-		for _, v := range vs {
+		for i, v := range vs {
+			if i != 0 {
+				out += "|"
+			}
 			out += fmt.Sprintf("%d", v)
 		}
 		return out
@@ -314,7 +341,10 @@ var unionNullIPAddressSerializer = `
 	func unionNullIPAddressSerializer(un UnionNullIPAddress) string {
 		if un.UnionType == UnionNullIPAddressTypeEnumIPAddress {
 			out := ""
-			for _, v := range un.IPAddress {
+			for i, v := range un.IPAddress {
+				if i != 0 {
+					out += "|"
+				}
 				out += fmt.Sprintf("%d", v)
 			}
 			return out

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -6,6 +6,24 @@ func AddUUIDSerializerToPackage(pkg *generator.Package) {
 	pkg.AddFile("uuid_serializers.go", uuidSerializersFileContent)
 }
 
+var allowedFieldTypes = map[string]bool{
+	"string": true, "[]string": true,
+	"bool": true, "[]bool": true,
+	"byte": true, "[]byte": true,
+
+	// int
+	"int": true, "[]int": true,
+	"int32": true, "[]int32": true,
+	"int64": true, "[]int64": true,
+
+	// float
+	"float32": true, "[]float32": true,
+	"float64": true, "[]float64": true,
+
+	// ip
+	"IPAddress": true,
+}
+
 var typeSerializerFuncs = map[string]string{
 	"byte": "byteSerializer", "[]byte": "byteSliceSerializer",
 	"bool": "boolSerializer", "[]bool": "boolSliceSerializer",

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -38,10 +38,6 @@ var allowedFieldTypes = map[string]bool{
 	"int32": true, "[]int32": true,
 	"int64": true, "[]int64": true,
 
-	// float
-	"float32": true, "[]float32": true,
-	"float64": true, "[]float64": true,
-
 	// ip
 	"IPAddress": true,
 
@@ -49,8 +45,6 @@ var allowedFieldTypes = map[string]bool{
 	"UnionNullString":    true,
 	"UnionNullInt":       true,
 	"UnionNullLong":      true,
-	"UnionNullFloat":     true,
-	"UnionNullDouble":    true,
 	"UnionNullBool":      true,
 	"UnionNullIPAddress": true,
 }
@@ -65,10 +59,6 @@ var typeSerializerFuncs = map[string]string{
 	"int32": "int32Serializer", "[]int32": "int32SliceSerializer",
 	"int64": "int64Serializer", "[]int64": "int64SliceSerializer",
 
-	// float
-	"float32": "float32Serializer", "[]float32": "float32SliceSerializer",
-	"float64": "float64Serializer", "[]float64": "float64SliceSerializer",
-
 	// IP related
 	"IPAddress": "ipSerializer",
 
@@ -76,8 +66,6 @@ var typeSerializerFuncs = map[string]string{
 	"UnionNullString":    "unionNullStringSerializer",
 	"UnionNullInt":       "unionNullIntSerializer",
 	"UnionNullLong":      "unionNullLongSerializer",
-	"UnionNullFloat":     "unionNullFloatSerializer",
-	"UnionNullDouble":    "unionNullDoubleSerializer",
 	"UnionNullBool":      "unionNullBoolSerializer",
 	"UnionNullIPAddress": "unionNullIPAddressSerializer",
 }
@@ -92,10 +80,6 @@ var serializers = map[string]string{
 	"int32": int32Serializer, "[]int32": int32SliceSerializer,
 	"int64": int64Serializer, "[]int64": int64SliceSerializer,
 
-	// float
-	"float32": float32Serializer, "[]float32": float32SliceSerializer,
-	"float64": float64Serializer, "[]float64": float64SliceSerializer,
-
 	// IP related
 	"IPAddress": ipSerializer,
 
@@ -103,8 +87,6 @@ var serializers = map[string]string{
 	"UnionNullString":    unionNullStringSerializer,
 	"UnionNullInt":       unionNullIntSerializer,
 	"UnionNullLong":      unionNullLongSerializer,
-	"UnionNullFloat":     unionNullFloatSerializer,
-	"UnionNullDouble":    unionNullDoubleSerializer,
 	"UnionNullBool":      unionNullBoolSerializer,
 	"UnionNullIPAddress": unionNullIPAddressSerializer,
 }
@@ -231,46 +213,6 @@ var int64SliceSerializer = `
 	}
 `
 
-// float32, float64
-
-var float32Serializer = `
-	func float32Serializer(v float32) string {
-		return fmt.Sprintf("%.4f", v)
-	}
-`
-
-var float64Serializer = `
-	func float64Serializer(v float64) string {
-		return fmt.Sprintf("%.4f", v)
-	}
-`
-
-var float32SliceSerializer = `
-	func float32SliceSerializer(vs []float32) string {
-		out := ""
-		for i, v := range vs {
-			if i != 0 {
-				out += ArraySeparator
-			}
-			out += fmt.Sprintf("%.4f", v)
-		}
-		return out
-	}
-`
-
-var float64SliceSerializer = `
-	func float64SliceSerializer(vs []float64) string {
-		out := ""
-		for i, v := range vs {
-			if i != 0 {
-				out += ArraySeparator
-			}
-			out += fmt.Sprintf("%.4f", v)
-		}
-		return out
-	}
-`
-
 // ip
 
 var ipSerializer = `
@@ -310,24 +252,6 @@ var unionNullLongSerializer = `
 	func unionNullLongSerializer(un UnionNullLong) string {
 		if un.UnionType == UnionNullLongTypeEnumLong {
 			return fmt.Sprintf("%d", un.Long)
-		}
-		return ""
-	}
-`
-
-var unionNullFloatSerializer = `
-	func unionNullFloatSerializer(un UnionNullFloat) string {
-		if un.UnionType == UnionNullFloatTypeEnumFloat {
-			return fmt.Sprintf("%.4f", un.Float)
-		}
-		return ""
-	}
-`
-
-var unionNullDoubleSerializer = `
-	func unionNullDoubleSerializer(un UnionNullDouble) string {
-		if un.UnionType == UnionNullDoubleTypeEnumDouble {
-			return fmt.Sprintf("%.4f", un.Double)
 		}
 		return ""
 	}

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -2,6 +2,8 @@ package types
 
 import "github.com/alanctgardner/gogen-avro/generator"
 
+// AddUUIDSerializerToPackage will add a file with Serializer functions
+// to the generated package code
 func AddUUIDSerializerToPackage(pkg *generator.Package) {
 	pkg.AddFile("uuid_serializers.go", uuidSerializersFileContent)
 }
@@ -31,12 +33,12 @@ var typeSerializerFuncs = map[string]string{
 
 	// int
 	"int": "intSerializer", "[]int": "intSliceSerializer",
-	"int32": "intSerializer", "[]int32": "intSliceSerializer",
-	"int64": "intSerializer", "[]int64": "intSliceSerializer",
+	"int32": "int32Serializer", "[]int32": "int32SliceSerializer",
+	"int64": "int64Serializer", "[]int64": "int64SliceSerializer",
 
 	// float
-	"float32": "floatSerializer", "[]float32": "floatSliceSerializer",
-	"float64": "floatSerializer", "[]float64": "floatSliceSerializer",
+	"float32": "float32Serializer", "[]float32": "float32SliceSerializer",
+	"float64": "float64Serializer", "[]float64": "float64SliceSerializer",
 
 	// IP related
 	"IPAddress": "ipSerializer",
@@ -48,111 +50,118 @@ import (
 	"reflect"
 )
 
-type fieldTypeSerializer func(interface{}) string
-
-var ipSerializer = fieldTypeSerializer(func(i interface{}) string {
+func ipSerializer(i interface{}) string {
 	vs := reflect.ValueOf(i).Convert(reflect.TypeOf([16]byte{})).Interface().([16]byte)
 	out := ""
 	for _, v := range vs {
 		out += fmt.Sprintf("%d", v)
 	}
 	return out
-})
+}
 
-var byteSerializer = fieldTypeSerializer(func(i interface{}) string {
-	v := i.(byte)
+// byte
+
+func byteSerializer(v byte) string {
 	return fmt.Sprintf("%d", v)
-})
+}
 
-var byteSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
-	vs := i.([]byte)
+func byteSliceSerializer(vs []byte) string {
 	out := ""
 	for _, v := range vs {
-		out += fmt.Sprintf("%d", v)
+		out += byteSerializer(v)
 	}
 	return out
-})
+}
 
-var stringSerializer = fieldTypeSerializer(func(i interface{}) string {
-	v := i.(string)
+// string
+
+func stringSerializer(v string) string {
 	return v
-})
+}
 
-var stringSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
-	vs := i.([]string)
+func stringSliceSerializer(vs []string) string {
 	out := ""
 	for _, v := range vs {
 		out += v
 	}
 	return out
-})
+}
 
-var boolSerializer = fieldTypeSerializer(func(i interface{}) string {
-	return fmt.Sprintf("%v", i)
-})
+// bool
 
-var boolSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
-	vs := i.([]bool)
+func boolSerializer(v bool) string {
+	return fmt.Sprintf("%v", v)
+}
+
+func boolSliceSerializer(vs []bool) string {
 	out := ""
 	for _, v := range vs {
-		out += fmt.Sprintf("%v", v)
+		out += boolSerializer(v)
 	}
 	return out
-})
+}
 
-var intSerializer = fieldTypeSerializer(func(i interface{}) string {
-	return fmt.Sprintf("%d", i)
-})
+// int, int32, int64
 
-var intSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
-	vsint, ok := i.([]int)
-	if ok {
-		out := ""
-		for _, v := range vsint {
-			out += fmt.Sprintf("%d", v)
-		}
-		return out
-	}
-	vsint32, ok := i.([]int32)
-	if ok {
-		out := ""
-		for _, v := range vsint32 {
-			out += fmt.Sprintf("%d", v)
-		}
-		return out
-	}
-	vsint64, ok := i.([]int64)
-	if ok {
-		out := ""
-		for _, v := range vsint64 {
-			out += fmt.Sprintf("%d", v)
-		}
-		return out
-	}
-	panic("invalid type: expected int, int32 or int64")
-})
+func intSerializer(v int) string {
+	return fmt.Sprintf("%d", v)
+}
 
-var floatSerializer = fieldTypeSerializer(func(i interface{}) string {
-	return fmt.Sprintf("%.4f", i)
-})
+func int32Serializer(v int32) string {
+	return fmt.Sprintf("%d", v)
+}
 
-var floatSliceSerializer = fieldTypeSerializer(func(i interface{}) string {
-	vsf32, ok := i.([]float32)
-	if ok {
-		out := ""
-		for _, v := range vsf32 {
-			out += fmt.Sprintf("%.4f", v)
-		}
-		return out
+func int64Serializer(v int64) string {
+	return fmt.Sprintf("%d", v)
+}
+
+func intSliceSerializer(vs []int) string {
+	out := ""
+	for _, v := range vs {
+		out += intSerializer(v)
 	}
-	vsf64, ok := i.([]float64)
-	if ok {
-		out := ""
-		for _, v := range vsf64 {
-			out += fmt.Sprintf("%.4f", v)
-		}
-		return out
+	return out
+}
+
+func int32SliceSerializer(vs []int32) string {
+	out := ""
+	for _, v := range vs {
+		out += int32Serializer(v)
 	}
-	panic("invalid type: expected float32 or float64")
-})
+	return out
+}
+
+func int64SliceSerializer(vs []int64) string {
+	out := ""
+	for _, v := range vs {
+		out += int64Serializer(v)
+	}
+	return out
+}
+
+// float32, float64
+
+func float32Serializer(v float32) string {
+	return fmt.Sprintf("%.4f", v)
+}
+
+func float64Serializer(v float64) string {
+	return fmt.Sprintf("%.4f", v)
+}
+
+func float32SliceSerializer(vs []float32) string {
+	out := ""
+	for _, v := range vs {
+		out += float32Serializer(v)
+	}
+	return out
+}
+
+func float64SliceSerializer(vs []float64) string {
+	out := ""
+	for _, v := range vs {
+		out += float64Serializer(v)
+	}
+	return out
+}
 `

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -19,12 +19,27 @@ var typeSerializerFuncs = map[string]string{
 	// float
 	"float32": "floatSerializer", "[]float32": "floatSliceSerializer",
 	"float64": "floatSerializer", "[]float64": "floatSliceSerializer",
+
+	// IP related
+	"IPAddress": "ipSerializer",
 }
 
 var uuidSerializersFileContent = `
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 type fieldTypeSerializer func(interface{}) string
+
+var ipSerializer = fieldTypeSerializer(func(i interface{}) string {
+	vs := reflect.ValueOf(i).Convert(reflect.TypeOf([16]byte{})).Interface().([16]byte)
+	out := ""
+	for _, v := range vs {
+		out += fmt.Sprintf("%d", v)
+	}
+	return out
+})
 
 var byteSerializer = fieldTypeSerializer(func(i interface{}) string {
 	v := i.(byte)

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -122,7 +122,7 @@ var byteSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -143,7 +143,7 @@ var stringSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += v
 		}
@@ -164,7 +164,7 @@ var boolSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%v", v)
 		}
@@ -197,7 +197,7 @@ var intSliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -210,7 +210,7 @@ var int32SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -223,7 +223,7 @@ var int64SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -250,7 +250,7 @@ var float32SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%.4f", v)
 		}
@@ -263,7 +263,7 @@ var float64SliceSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%.4f", v)
 		}
@@ -278,7 +278,7 @@ var ipSerializer = `
 		out := ""
 		for i, v := range vs {
 			if i != 0 {
-				out += "|"
+				out += ","
 			}
 			out += fmt.Sprintf("%d", v)
 		}
@@ -348,7 +348,7 @@ var unionNullIPAddressSerializer = `
 			out := ""
 			for i, v := range un.IPAddress {
 				if i != 0 {
-					out += "|"
+					out += ","
 				}
 				out += fmt.Sprintf("%d", v)
 			}


### PR DESCRIPTION
- Added `AddFile` to `generator.Package` - allowing you to add an entire raw file to the package.
- Added well defined functions for serializing different primitive types. These functions should be easily replicated in other languages.
- Allows for using nested fields for UUID generation; e.g `"object.name"`.

Supported types:
`int`, `long`, `float`, `double`, `bool`, `string`, `byte` and their array derivatives.
`ip_address` (as defined in `com.securityscorecard.common.ip_address`).
Additionally, union types are supported for the above primitive types an `ip_address`, although not for their array derivatives.

Example output for `GenerateID`:

```go
func (r *ARecord) GenerateID() string {
	s := fmt.Sprintf("%s%s%s", ipSerializer(r.IPAddress), stringSerializer(r.Name), stringSerializer(r.Object.Name))
	return uuid.NewV5(uuid.NamespaceOID, s).String()
}
```

**Notice**: This change will require changes to schemas as some types we currently generate UUIDs based on will no longer be supported.

![](https://media.giphy.com/media/xT0BKiK5sOCVdBUhiM/giphy-downsized.gif)