### PR TITLE
Allow duplicate showings of imported schema

### DIFF
--- a/types/fixed.go
+++ b/types/fixed.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/alanctgardner/gogen-avro/generator"
 )
 
@@ -87,9 +88,6 @@ func (s *FixedDefinition) ResolveReferences(n *Namespace) error {
 
 func (s *FixedDefinition) Schema(names map[QualifiedName]interface{}) interface{} {
 	name := s.name.String()
-	if _, ok := names[s.name]; ok {
-		return name
-	}
 	names[s.name] = 1
 	return mergeMaps(map[string]interface{}{
 		"type": "fixed",


### PR DESCRIPTION
This fixes an issue where if a certain record type was already seen (in this case ip_address) then the next time it was seen it would just return the name vs the actual type definition.