### PR TITLE
Fix uuid serializers not ALL being written to file

### DIFF
--- a/test/uuid/generate.go
+++ b/test/uuid/generate.go
@@ -1,3 +1,3 @@
 package avro
 
-//go:generate $GOPATH/bin/gogen-avro . uuid.avsc
+//go:generate $GOPATH/bin/gogen-avro . uuid_mini.avsc uuid.avsc

--- a/test/uuid/uuid_mini.avsc
+++ b/test/uuid/uuid_mini.avsc
@@ -1,0 +1,15 @@
+{
+    "type": "record",
+    "namespace": "com.securityscorecard.collections",
+    "name": "uuid_mini",
+    "subject": "com.securityscorecard.collections.uuid_mini",
+    "fields": [
+        {
+            "name": "string",
+            "type": "string"
+        }
+    ],
+    "uuid_keys": [
+        "string"
+    ]
+}

--- a/types/uuid_serializers.go
+++ b/types/uuid_serializers.go
@@ -14,7 +14,11 @@ func AddUUIDSerializerToPackage(pkg *generator.Package, requiredSerializers []st
 		return
 	}
 
-	fileContent := uuidSerializersFileContent
+	fName := "uuid_serializers.go"
+
+	pkg.AddImport(fName, "fmt")
+	pkg.AddConstant(fName, "FieldSeparator", string(0x1E))
+	pkg.AddConstant(fName, "ArraySeparator", string(0x1F))
 
 	for _, reqSer := range requiredSerializers {
 		ser, ok := serializers[reqSer]
@@ -22,10 +26,8 @@ func AddUUIDSerializerToPackage(pkg *generator.Package, requiredSerializers []st
 			panic(fmt.Sprintf("uuid serializer for %s not found", reqSer))
 		}
 
-		fileContent += fmt.Sprintf("\n%s\n", ser)
+		pkg.AddFunction(fName, "", reqSer, ser)
 	}
-
-	pkg.AddFile("uuid_serializers.go", fileContent)
 }
 
 var allowedFieldTypes = map[string]bool{
@@ -280,15 +282,4 @@ var unionNullIPAddressSerializer = `
 		}
 		return ""
 	}
-`
-
-var uuidSerializersFileContent = `
-import (
-	"fmt"
-)
-
-const (
-	FieldSeparator = string(0x1E)
-	ArraySeparator = string(0x1F)
-)
 `


### PR DESCRIPTION
Previously, uuid serializers were being written for the first schema encountered and not for any past that.