### PR TITLE
Add a suffix to nested type names based on the times they've been seen

### DIFF
--- a/types/fixed.go
+++ b/types/fixed.go
@@ -90,9 +90,15 @@ func (s *FixedDefinition) Schema(names map[QualifiedName]interface{}) interface{
 	name := s.name.String()
 
 	// If name already seen
-	if _, ok := names[s.name]; ok {
-		// Add a small hash suffix to the name to avoid name collisions
-		name += "_" + hash()
+	if v, ok := names[s.name]; ok {
+		// v is times name was seen
+		ts := v.(int)
+
+		// Add a suffix to the name to avoid name collisions
+		name += "_" + fmt.Sprintf("%d", ts)
+
+		// Update the times seen count
+		names[s.name] = ts + 1
 	}
 
 	// mark name as seen

--- a/types/record.go
+++ b/types/record.go
@@ -185,9 +185,15 @@ func (r *RecordDefinition) Schema(names map[QualifiedName]interface{}) interface
 	name := r.name.Name
 
 	// If name already seen
-	if _, ok := names[r.name]; ok {
-		// Add a small hgash suffix to the name to avoid name collisions
-		name += "_" + hash()
+	if v, ok := names[r.name]; ok {
+		// v is times name was seen
+		ts := v.(int)
+
+		// Add a suffix to the name to avoid name collisions
+		name += "_" + fmt.Sprintf("%d", ts)
+
+		// Update the times seen count
+		names[r.name] = ts + 1
 	}
 
 	// mark name as seen


### PR DESCRIPTION
Currently when a nested record is seen twice in a schema, a random hash suffix is added to it's name.
The goal was to make sure identical nested record types have different names to avoid name collisions downstream.

The issue is that because the names are random, every time we generate code we get new names, introducing redundant changes which are annoying to review.

This just uses a counter for the suffix which shouldn't change between code generation runs.