### PR TITLE
Improve uuid_keys error message.

### DIFF
--- a/types/record.go
+++ b/types/record.go
@@ -328,12 +328,13 @@ func (r *RecordDefinition) uuidStrDef() (string, []string) {
 	for _, uuidKey := range schema.UUIDKeys {
 		fName := uuidToFieldName(uuidKey)
 		if _, ok := availableFields[fName]; !ok {
-			fmt.Printf("Error: can't use %s as a uuid key\n", uuidKey)
-			keys := []string{}
-			for key := range availableFields {
-				keys = append(keys, strings.ToLower(key))
+			fmt.Printf("Error: can't use %s as a uuid key\n", fName)
+			fields := []string{}
+			for field := range availableFields {
+				fields = append(fields, field)
 			}
-			fmt.Printf("Error: valid UUID keys are %s\n", strings.Join(keys, ", "))
+			fmt.Printf("Error: valid UUID keys %s\n", strings.Join(fields, ", "))
+			fmt.Printf("Error: the keys above are shown in Go format (CamelCase), but must be declared in uuid_keys using the Avro format (snake_case).\n")
 			os.Exit(1)
 		}
 

--- a/types/record.go
+++ b/types/record.go
@@ -329,6 +329,11 @@ func (r *RecordDefinition) uuidStrDef() (string, []string) {
 		fName := uuidToFieldName(uuidKey)
 		if _, ok := availableFields[fName]; !ok {
 			fmt.Printf("Error: can't use %s as a uuid key\n", uuidKey)
+			keys := []string{}
+			for key := range availableFields {
+				keys = append(keys, strings.ToLower(key))
+			}
+			fmt.Printf("Error: valid UUID keys are %s\n", strings.Join(keys, ", "))
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
In https://github.com/securityscorecard/collection-schemas/pull/187 there was a problem understanding what the proper name for a filed would be. This change improves the error message to not only say "no", but also tell the user what acceptable values are.