### PR TITLE
Add SchemaVersion method.

### DIFF
--- a/types/record.go
+++ b/types/record.go
@@ -141,8 +141,9 @@ func (r *RecordDefinition) AddStruct(p *generator.Package) {
 		}
 		p.AddFunction(r.filename(), r.GoType(), "Schema", r.schemaMethod())
 
-		// For Records we also want to add a GenerateID and SendStats methods
+		// For Records we also want to add other utility methods.
 		r.AddGenerateID(p)
+		r.AddSchemaVersion(p)
 		r.AddSendStats(p)
 	}
 }

--- a/types/schema.go
+++ b/types/schema.go
@@ -166,9 +166,13 @@ func (n *Namespace) decodeRecordDefinition(namespace string, schemaMap map[strin
 		decodedFields = append(decodedFields, fieldStruct)
 	}
 
-	version, ok := schemaMap["version"]
-	if !ok {
-		return nil, fmt.Errorf("No version found in schema.")
+	// Version doesn't exist for every schema, frustratingly. So the zero
+	// value, which we never use as a version, will indicate its absence.
+	var version int
+	if untypedVersion, ok := schemaMap["version"]; ok {
+		if floatVersion, ok := untypedVersion.(float64); ok {
+			version = int(floatVersion)
+		}
 	}
 
 	aliases, err := parseAliases(schemaMap, namespace)

--- a/types/schema.go
+++ b/types/schema.go
@@ -166,6 +166,11 @@ func (n *Namespace) decodeRecordDefinition(namespace string, schemaMap map[strin
 		decodedFields = append(decodedFields, fieldStruct)
 	}
 
+	version, ok := schemaMap["version"]
+	if !ok {
+		return nil, fmt.Errorf("No version found in schema.")
+	}
+
 	aliases, err := parseAliases(schemaMap, namespace)
 	if err != nil {
 		return nil, err
@@ -173,6 +178,7 @@ func (n *Namespace) decodeRecordDefinition(namespace string, schemaMap map[strin
 
 	return &RecordDefinition{
 		name:     ParseAvroName(namespace, name),
+		version:  version,
 		aliases:  aliases,
 		fields:   decodedFields,
 		metadata: schemaMap,


### PR DESCRIPTION
For the [REDACTED], it is useful to know what the version of the schema I can parse is. The library currently doesn't tell me, so I have to either hardwire it, or try and fail and treat EOF errors (caused by earlier versions) specially. Adding this method was pretty easy, and cleaner.